### PR TITLE
Now deduces extension using imghdr

### DIFF
--- a/PhotoScraper/RPI_SIS_PhotoScraper.py
+++ b/PhotoScraper/RPI_SIS_PhotoScraper.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from PIL import Image
+import imghdr
 import getpass, requests, os, re
 from pathlib import Path
 from selenium.webdriver.support.ui import Select
@@ -123,17 +123,17 @@ def saveImagesToFolder(term, course, class_list):
         r = requests.get(img_url)
 
         #Open the image use PIL.Image to deduce the extension
-        img = Image.open(BytesIO(r.content))
+        img_format = imghdr.what(BytesIO(r.content)).lower()
         img_name = rcs_id
-        if img.format == "JPEG":
+        if img_format == "jpeg":
             img_name = img_name + ".jpg"
         else:
-            img_name = img_name + "." + img.format.lower()
+            img_name = img_name + "." + img_format
         filepath = path / img_name
 
         #Actually write the file. We could skip the context manager and just use Image.save(filepath)
         with open(str(filepath),'wb') as f:
-            img.save(f)
+            f.write(r.content)
             print("Saved photo for student rcs {}".format(rcs_id))
 
 # returns the class list of dictionaries of info collected about each student's img url, name, and email

--- a/PhotoScraper/RPI_SIS_PhotoScraper.py
+++ b/PhotoScraper/RPI_SIS_PhotoScraper.py
@@ -123,7 +123,7 @@ def saveImagesToFolder(term, course, class_list):
         r = requests.get(img_url)
 
         #Deduce the extension, build the output path
-        img_format = imghdr.what(None,BytesIO(r.content).read()).lower()
+        img_format = imghdr.what(None,r.content).lower()
         img_name = rcs_id + "." + img_format
         filepath = path / img_name
 

--- a/PhotoScraper/RPI_SIS_PhotoScraper.py
+++ b/PhotoScraper/RPI_SIS_PhotoScraper.py
@@ -122,13 +122,9 @@ def saveImagesToFolder(term, course, class_list):
             continue
         r = requests.get(img_url)
 
-        #Open the image use PIL.Image to deduce the extension
-        img_format = imghdr.what(BytesIO(r.content)).lower()
-        img_name = rcs_id
-        if img_format == "jpeg":
-            img_name = img_name + ".jpg"
-        else:
-            img_name = img_name + "." + img_format
+        #Deduce the extension, build the output path
+        img_format = imghdr.what(None,BytesIO(r.content).read()).lower()
+        img_name = rcs_id + "." + img_format
         filepath = path / img_name
 
         #Actually write the file. We could skip the context manager and just use Image.save(filepath)

--- a/PhotoScraper/RPI_SIS_PhotoScraper.py
+++ b/PhotoScraper/RPI_SIS_PhotoScraper.py
@@ -1,4 +1,3 @@
-from io import BytesIO
 import imghdr
 import getpass, requests, os, re
 from pathlib import Path


### PR DESCRIPTION
Partially Submitty/Submitty#3704.

Edit: As per https://github.com/Submitty/Submitty/blob/master/site/app/views/grading/ImagesView.php right now it is hard coded to use files ending in ".png" so that will have to be fixed in the Submitty/Submitty repo once this PR is added.

~~The documentation will have to be updated to explain installing `pillow` for Python, so this does not quite close the issue.~~

~~If we don't want an additional package dependency we could be sloppy and just hardcode to always use .jpg, but that would have the disadvantage of being prone to failure if SIS ever changes their image format to PNG or BMP or something.~~