### PR TITLE
[Feature:QR_Maker] Set error correction to maximum when making QR

### DIFF
--- a/QR_TestMaker/make_all.py
+++ b/QR_TestMaker/make_all.py
@@ -196,12 +196,14 @@ def make_all_exams():
                 subprocess.call(['mv',filename,'to_print/'+zone+'/'+filename])
 
         qr = qrcode.QRCode(
-            version = 1,
-            #error_correction = qrcode.constants.ERROR_CORRECT_H, _L, _M, _Q, _H
+            version = None,
+            error_correction = qrcode.constants.ERROR_CORRECT_H,
             box_size = 10,
             border = 4,
         )
         qr.add_data(blank_data)
+        qr.make(fit=True)
+
         img = qr.make_image()
         img.save(qr_dir+'/' + blank_data + '.png') #can also be .bmp, .jpeg
         


### PR DESCRIPTION
Modifies the QR maker tool to use maximum error correction when creating QR codes,
this should allocate more space for better handling in the QR. 

Also also automatically allows the maker to increase the size of the QR matrix for larger data if needed. 

Should improve results when scanning on the Bulk Upload System