### PR TITLE
Solve Long Contact Info Causing PhotoScraper Crash

### DIFF
--- a/PhotoScraper/RPI_SIS_PhotoScraper.py
+++ b/PhotoScraper/RPI_SIS_PhotoScraper.py
@@ -209,7 +209,9 @@ def getStudentInfoFromCourse(driver, select_course, index, class_list):
         print("Gathering info for student: "+name)
 
         # email address
-        driver.find_element_by_link_text('Student E-mail Address').click()
+        email_element = driver.find_element_by_link_text('Student E-mail Address')
+        email_element.send_keys(Keys.DOWN)
+        email_element.click()
         if len(driver.find_elements_by_class_name('datadisplaytable')) == 1:
             emails = driver.find_element_by_class_name('datadisplaytable').find_element_by_tag_name('tbody').find_elements_by_tag_name('tr')
             for i in range(len(emails)):


### PR DESCRIPTION
Because Selenium/WebDriver requires an element to be in view before it can be clicked, if a student has long enough address information on their information page (multiple addresses, many lines per address), the "Student E-mail Address" link may not be visible without scrolling. This PR resolves that issue by attempting to scroll using `send_keys()`.

Tested on Windows 10 with Chrome 79 and a student that was causing the script to crash without this fix.