### PR TITLE
[Refactor:InstructorUI] Remove driver.get(current url)

### DIFF
--- a/PhotoScraper/RPI_SIS_PhotoScraper.py
+++ b/PhotoScraper/RPI_SIS_PhotoScraper.py
@@ -446,9 +446,6 @@ def getStudentInfoFromCourseHelper(driver, term, class_list):
             input()
             raise
 
-        img_url = driver.current_url
-        driver.get(img_url)
-
         # image, initalize to empty string
         student_record["img url"] = ""
         image_arr = driver.find_elements(By.TAG_NAME, "img")


### PR DESCRIPTION
In `getStudentInfoFromCourseHelper`, the photo scraper currently has the following line:
```
        img_url = driver.current_url
        driver.get(img_url)
```
`img_url` is used nowhere else in the function, so it appears that this statement doesn't do anything, and probably slows down the scraper a little by running an unnecessary Selenium command.